### PR TITLE
chore: update tonic 0.8 -> 0.9, gcloud-sdk 0.19.19 -> 0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "gcloud-sdk"
-version = "0.19.19"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bc55335a0613a2fe711f4c7733aff3adb4c1175aa81b3a3640d666efa7d94d"
+checksum = "ccfb23ea22b974b1df8b0e4501064aae70c506e5f1c187da1a0ed8501655714b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1732,9 +1732,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2745,13 +2745,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tower-service",
  "url",
@@ -2861,6 +2861,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,6 +2891,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3533,9 +3555,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
 ]
 
 [[package]]
@@ -3557,9 +3589,9 @@ checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tungstenite",
  "webpki",
  "webpki-roots",
@@ -3615,14 +3647,14 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "38bd8e87955eb13c1986671838177d6792cdc52af9bffced0d2c8a9a7f741ab3"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3634,18 +3666,15 @@ dependencies = [
  "percent-encoding",
  "pin-project 1.0.12",
  "prost",
- "prost-derive",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -3754,7 +3783,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.20.8",
  "sha1",
  "thiserror",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-gcp-kms-signer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = " ethers-rs signer using GCP KMS"
 repository = "https://github.com/georgewhewell/ethers-gcp-kms-signer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ include = ["**/*.rs"]
 [dependencies]
 async-trait = "0.1.68"
 ethers = "2.0.2"
-gcloud-sdk = { version = "0.19.19", features = ["google-cloud-kms-v1"] }
+gcloud-sdk = { version = "0.20.1", features = ["google-cloud-kms-v1"] }
 thiserror = "1.0.40"
-tonic = "0.8"
+tonic = "0.9"
 tracing = "0.1.37"
 
 [dependencies.spki]


### PR DESCRIPTION
tonic 0.8 -> 0.9
gcloud-sdk 0.19.19 -> 0.20.1

<!--
Please, make sure:
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/georgewhewell/ethers-gcp-kms-signer/blob/main/CHANGELOG.md
-->
